### PR TITLE
Fix failure handler typo

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: c7d260bbedb081ed41c4aaa84e3810d210102e41
+    changeNotes: Fix failure handler typo.
   - sha: ac7c46d255a1f15f4b5bcd6af14d923640ea6f26
     changeNotes: Support for Visitor Identification.
   - sha: 6842852ed352c0055840ce7dd14cc72f3a3190c1

--- a/template.js
+++ b/template.js
@@ -42,7 +42,7 @@ const handler = actionHandlers[data.type];
 if (handler) {
   handler();
 } else {
-  data.onGtmFailure();
+  data.gtmOnFailure();
 }
 
 /******************************************************************************/

--- a/template.tpl
+++ b/template.tpl
@@ -575,7 +575,7 @@ const handler = actionHandlers[data.type];
 if (handler) {
   handler();
 } else {
-  data.onGtmFailure();
+  data.gtmOnFailure();
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Fixed a typo when calling the failure template handler when a handler for the template possible events is not found.

This `else` clause is unreachable. It would only be executed if someone added a new option to the template UI and didn't create a corresponding handler.